### PR TITLE
fixed the chat history issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@
 | 🌱 **Crop Recommender** | Suggests crops based on region, season, and soil |
 | 🧾 **Govt. Schemes** | Latest schemes for farmers (male & female) |
 | 🤖 **ChatBot (Coming Soon)** | Get farming advice instantly using Q&A bot |
+| :--- | :--- |
+| 👩‍⚕️ **Expert Diagnosis** | Get a detailed action plan (diagnosis, organic/chemical solutions, productivity tips) from an AI agronomist. |
+| 🌿 **Crop Health** | Upload a photo of a crop leaf and the AI will detect the disease. |
+| 📈 **Mandi Prices** | Get real-time commodity prices from local markets (mandis) with insights on the best prices. |
+| 🌍 **Crop Recommendations** | Recommends suitable crops based on your agro-climatic zone. |
+| 📜 **Govt. Schemes** | Finds relevant government schemes based on a farmer's profile. |
+| 💬 **AI ChatBot** | Ask farming-related questions in your native language and get instant answers. |
+| 🗣️ **BhashaBuddy (TTS)** | Listen to AI-generated advice in multiple Indian languages. |
+| ☀️ **Weather Forecast** | Provides current weather data for any location. |
 
 ---
 
@@ -44,6 +53,10 @@
 - **ML Libraries**: OpenCV, scikit-learn (upcoming)
 - **APIs**: OpenWeatherMap, Agmarknet
 - **Tools**: `gTTS`, `Pillow`, `Geopy`, `Requests`
+- **Backend Framework**: FastAPI
+- **AI/ML**: Google Gemini, `gTTS`
+- **APIs**: OpenWeatherMap, data.gov.in (Agmarknet)
+- **Core Libraries**: `Requests`, `Pydantic`, `Pillow`
 
 ---
 
@@ -59,6 +72,11 @@ KrishiMitra/
 ├── data/               # JSON / CSV files
 ├── assets/             # Images / audio
 ├── krishimitra_app.py  # Main app
+├── backend/
+│   ├── features/       # Logic for each feature (weather, chatbot, etc.)
+│   ├── data/           # Data files like agri_knowledge.json
+│   └── main.py         # FastAPI backend server
+├── app.py              # Streamlit frontend application
 ├── requirements.txt
 └── README.md
 


### PR DESCRIPTION
Issue: Chat History Not Persisting

Description:
The chatbot works fine for single prompts, but it’s stateless — it doesn’t remember past messages. The backend already supports receiving chat history, but the frontend (app.py) isn’t sending it.

Expected behavior:

The assistant should remember previous user inputs and responses.

Each new response should take the full conversation history into account.

Steps to Reproduce:

Start the chatbot.

Ask a question.

Ask a follow-up question — the assistant doesn’t remember context.

Cause:
st.session_state is not being used to store and send chat history

Related Issue
#65 